### PR TITLE
Fix: make python module generation absolute to the right directory

### DIFF
--- a/build.go
+++ b/build.go
@@ -383,7 +383,7 @@ func buildPython() {
 
 	var initFiles []string
 	for _, f := range modules {
-		initPy := f + "/__init__.py"
+		initPy := fmt.Sprintf("%s/%s/%s", "build/python-cs3apis", f, "__init__.py")
 		initFiles = append(initFiles, initPy)
 	}
 


### PR DESCRIPTION
This was preventing the `__init__.py` files from being staged on `buildPython()` - as detected on https://github.com/cs3org/wopiserver/issues/31#issuecomment-740557214 