### PR TITLE
'custom_dns' in docker build steps to workaround dind DNS issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,3 +28,6 @@ steps:
       from_secret: dockerhub_username
     password:
       from_secret: dockerhub_password
+    custom_dns:
+      - 128.142.17.5
+      - 128.142.16.5


### PR DESCRIPTION
Note: this disables cloud.drone.io from building the images, as the alternative DNS servers are internal-only