### PR TITLE
allow adding third party protobuf

### DIFF
--- a/build.go
+++ b/build.go
@@ -307,7 +307,7 @@ func buildProto() {
 	files := findProtos()
 	fmt.Println(files)
 
-	args := []string{"--doc_out=./docs", "--doc_opt=html,index.html"}
+	args := []string{"--doc_out=./docs", "--doc_opt=html,index.html", "-I=.", "-I=./third_party"}
 	args = append(args, files...)
 	cmd = exec.Command("protoc", args...)
 	run(cmd)


### PR DESCRIPTION
We want to use the `google.protobuf.FieldMask` for updating shares. For that we need to be able to use third party protobuf ... or we switch to ̀[`buf`](https://github.com/bufbuild/buf), since `prototool` is in maintenance mode only and actually recommends `buf` in their readme.